### PR TITLE
Allow multiple name changes

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -41,8 +41,8 @@ angular.module('toggle-ui.controllers', [])
 
     $scope.update = function(toggle) {
         var originalName = toggle.originalName;
-        toggle.$put();
         toggle.originalName = toggle.name;
+        toggle.$put();
 
         if (originalName != '' && originalName != toggle.name) {
             var oldToggle = {};
@@ -77,7 +77,9 @@ angular.module('toggle-ui.controllers', [])
     }
 
     $scope.addInSetValue = function(value, operator, scope) {
-        operator.values.push(value);
+        if (operator.values.indexOf(value) == -1) {
+            operator.values.push(value);
+        }
         scope.inSetValue = '';
     }
 

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -40,14 +40,16 @@ angular.module('toggle-ui.controllers', [])
     }
 
     $scope.update = function(toggle) {
-      toggle.$put();
+        var originalName = toggle.originalName;
+        toggle.$put();
+        toggle.originalName = toggle.name;
 
-      if (toggle.originalName != '' && toggle.originalName != toggle.name) {
-          var oldToggle = {};
-          angular.copy(toggle, oldToggle);
-          oldToggle.name = toggle.originalName;
-          oldToggle.$delete();
-      }
+        if (originalName != '' && originalName != toggle.name) {
+            var oldToggle = {};
+            angular.copy(toggle, oldToggle);
+            oldToggle.name = originalName;
+            oldToggle.$delete();
+        }
     }
 
     $scope.add = function() {

--- a/app/partials/toggles.html
+++ b/app/partials/toggles.html
@@ -13,7 +13,7 @@
   </thead>
   <tbody ng-repeat="toggle in toggles" class="toggle">
     <tr>
-      <td><input ng-model="toggle.name"></td>
+      <td><input ng-model="toggle.name" ng-enter="update(toggle)"></td>
       <td><select ng-model="toggle.status" ng-options="s.value as s.label for s in statuses"></select></td>
       <td>
         <a href ng-click="addCondition(toggle)" class="btn btn-small btn-primary">ADD Condition</a>

--- a/test/unit/controllersSpec.js
+++ b/test/unit/controllersSpec.js
@@ -214,5 +214,27 @@ describe('toggle-ui controllers', function(){
 
       expect(scope.toggles[0]).toEqualData(newToggle);
     });
+
+    it('ignores duplicates when calling inSetValue', function() {
+      $httpBackend.flush(); // load the toggles
+
+      var toggle = scope.toggles[0];
+      var condition = toggle.conditions[1]; // in-set condition
+
+      scope.addInSetValue(1337, condition.operator, scope);
+
+      expect(scope.toggles[0].conditions[1].operator.values).toEqualData([1337, 1028]);
+    });
+
+    it('adds a value when calling addInSetValue', function() {
+      $httpBackend.flush(); // load the toggles
+
+      var toggle = scope.toggles[0];
+      var condition = toggle.conditions[1]; // in-set condition
+
+      scope.addInSetValue("test", condition.operator, scope);
+
+      expect(scope.toggles[0].conditions[1].operator.values).toEqualData([1337, 1028, "test"]);
+    });
   });
 });

--- a/test/unit/controllersSpec.js
+++ b/test/unit/controllersSpec.js
@@ -187,7 +187,30 @@ describe('toggle-ui controllers', function(){
       $httpBackend.flush();
 
       var newToggle = togglesData[0];
-      newToggle.name = 'toggling4';
+      newToggle.originalName = newToggle.name = 'toggling4';
+
+      expect(scope.toggles[0]).toEqualData(newToggle);
+    });
+
+    it('can do a second rename', function() {
+      $httpBackend.flush(); // load the toggles
+
+      var toggle = scope.toggles[0];
+
+      toggle.name = 'toggling5';
+
+      $httpBackend.expectPUT('http://127.0.0.1:8080/toggles/toggling5').
+      respond(204, '');
+
+      $httpBackend.expectDELETE('http://127.0.0.1:8080/toggles/toggling4').
+      respond(200, '');
+
+      scope.update(toggle);
+
+      $httpBackend.flush();
+
+      var newToggle = togglesData[0];
+      newToggle.originalName = newToggle.name = 'toggling5';
 
       expect(scope.toggles[0]).toEqualData(newToggle);
     });


### PR DESCRIPTION
Changing the name of a toggle multiple times within the same requests yield errors. This PR resolves this issue.

It also binds the enter key to the name input field.

The final commit "fixes" the fact that the save button appears for all toggles when a single toggle is changed. And it will also remove the save button again once saved.

Sidenotes:

* CS Was inconsistent, so I used 4 spaces
* Changes are in separate commits, let me know if there is anything you don't like and I'll remove it
* My intend was just to do a little practice with angular :)
* Didn't get the e2e tests to work `failed to proxy /app/index-e2e.html`
* Had to be [creative](https://github.com/qandidate-labs/qandidate-toggle-ui/pull/3/commits/ecab77aac56ff5b16a05b56870cebb54c20c5da9#diff-40084eb42a8e52b0a5ff0264ef426c94R54) to remove the dirty class from the form not sure how bad it is...
  (The controller is bound to the toggleForm in the scope)